### PR TITLE
Feature/safe finalized

### DIFF
--- a/transports/manager.go
+++ b/transports/manager.go
@@ -40,8 +40,15 @@ func (tm *TransportManager) RegisterMiddleware(item rpc.Middleware) {
   tm.registry.RegisterMiddleware(item)
 }
 
-func (tm *TransportManager) RegisterHeightFeed(ch <-chan int64) {
-	tm.registry.RegisterHeightFeed(ch)
+func (tm *TransportManager) RegisterHeightFeed(ch interface{}) {
+	switch v := ch.(type) {
+	case chan int64:
+		tm.registry.RegisterHeightFeed(v)
+	case chan *rpc.HeightRecord:
+		tm.registry.RegisterHeightRecordFeed(v)
+	default:
+		log.Error("Height feed must be one of (chan int64) or (chan *rpc.HeightRecord). Height feed not registered!")
+	}
 }
 
 func (tm *TransportManager) RegisterHealthCheck(hc rpc.HealthCheck) {

--- a/types.go
+++ b/types.go
@@ -115,20 +115,39 @@ func (cm *CallContext) Get(key string) (interface{}, bool) {
 type latestUnmarshaller struct {
   lock *sync.Mutex
 	latestList []*BlockNumber
+	safeList []*BlockNumber
+	finalizedList []*BlockNumber
 }
 
 func (lm *latestUnmarshaller) Add(b *BlockNumber) {
 	lm.latestList = append(lm.latestList, b)
 }
+func (lm *latestUnmarshaller) AddFinalized(b *BlockNumber) {
+	lm.finalizedList = append(lm.finalizedList, b)
+}
+func (lm *latestUnmarshaller) AddSafe(b *BlockNumber) {
+	lm.safeList = append(lm.safeList, b)
+}
 
-func (lm *latestUnmarshaller) Resolve(await func(int64) bool, latest int64) {
+func (lm *latestUnmarshaller) Resolve(await func(int64) bool, finalized, safe, latest int64) {
 	ll := lm.latestList
 	lm.latestList = []*BlockNumber{}
+	fl := lm.finalizedList
+	lm.finalizedList = []*BlockNumber{}
+	sl := lm.safeList
+	lm.safeList = []*BlockNumber{}
 	lm.lock.Unlock()
 	if len(ll) > 0 && await(latest) {
 		for _, p := range ll {
 			*p = BlockNumber(latest)
 		}
+	}
+	// We don't need to await for safe or finalized, since those are older block numbers anyway.
+	for _, p := range fl {
+		*p = BlockNumber(finalized)
+	}
+	for _, p := range sl {
+		*p = BlockNumber(safe)
 	}
 }
 
@@ -138,10 +157,10 @@ func init() {
   lm = &latestUnmarshaller{lock: &sync.Mutex{}, latestList: []*BlockNumber{}}
 }
 
-func (lm *latestUnmarshaller) Unmarshal(data []byte, value interface{}, latest int64, await func(int64) bool) error {
+func (lm *latestUnmarshaller) Unmarshal(data []byte, value interface{}, finalized, safe, latest int64, await func(int64) bool) error {
   if latest != -1 {
 		lm.lock.Lock()
-		defer lm.Resolve(await, latest)
+		defer lm.Resolve(await, finalized, safe, latest)
   }
   return json.Unmarshal(data, value)
 }
@@ -150,9 +169,11 @@ func (lm *latestUnmarshaller) Unmarshal(data []byte, value interface{}, latest i
 type BlockNumber int64
 
 const (
-  PendingBlockNumber  = BlockNumber(-2)
-  LatestBlockNumber   = BlockNumber(-1)
-  EarliestBlockNumber = BlockNumber(0)
+  FinalizedBlockNumber = BlockNumber(-4)
+  SafeBlockNumber      = BlockNumber(-3)
+  PendingBlockNumber   = BlockNumber(-2)
+  LatestBlockNumber    = BlockNumber(-1)
+  EarliestBlockNumber  = BlockNumber(0)
 )
 
 func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
@@ -169,6 +190,14 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
   case "pending":
     *bn = PendingBlockNumber
     return nil
+	case "safe":
+		lm.AddSafe(bn)
+		*bn = SafeBlockNumber
+		return nil
+	case "finalized":
+		lm.AddFinalized(bn)
+		*bn = FinalizedBlockNumber
+		return nil
   }
 
   n, err := hexutil.DecodeUint64(v)
@@ -184,6 +213,10 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 
 func (bn BlockNumber) MarshalJSON() ([]byte, error) {
 	switch bn {
+	case -4:
+		return []byte(`"finalized"`), nil
+	case -3:
+		return []byte(`"safe"`), nil
 	case -2:
 		return []byte(`"pending"`), nil
 	case -1:
@@ -191,4 +224,10 @@ func (bn BlockNumber) MarshalJSON() ([]byte, error) {
 	default:
 		return json.Marshal(hexutil.Uint(bn))
 	}
+}
+
+type HeightRecord struct {
+	Latest    int64
+	Safe      *int64
+	Finalized *int64
 }


### PR DESCRIPTION
This extends the height feed to take a new HeightRecord, which can
include safe/finalized information, and "safe" or "finalized" values
in RPCBlockNumber types will JSON unmarshal to the latest safe /
finalized value on the height feed.

The new heightfeed is registered through a different method than the
old one to keep backwards compatibility for the time being.
