### PR TITLE
Nil pointer checks in latest unmarshaller

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -546,6 +546,14 @@ func (reg *registry) subscribe(cctx *CallContext, method string, args []json.Raw
 	return subid, nil, cctx.meta
 }
 
+func fmtArgs(args []json.RawMessage) string {
+	argStrings := make([]string, len(args))
+	for i, arg := range args {
+		argStrings[i] = string(arg)
+	}
+	return strings.Join(argStrings, ", ")
+}
+
 func (reg *registry) call(cctx *CallContext, method string, args []json.RawMessage) (res interface{}, errRes *RPCError, cm *CallMetadata) {
 	cb, ok := reg.callbacks[method]
 	if !ok {
@@ -564,7 +572,7 @@ func (reg *registry) call(cctx *CallContext, method string, args []json.RawMessa
 			buf := make([]byte, size)
 			buf = buf[:runtime.Stack(buf, false)]
 			crashMeter.Inc(1)
-			log.Error("RPC method " + method + " crashed: " + fmt.Sprintf("%v\n%s", err, buf))
+			log.Error("RPC method " + method + "("+ fmtArgs(args) +") crashed: " + fmt.Sprintf("%v\n%s", err, buf))
 			errRes = NewRPCError(-1, "method handler crashed")
 			cm = cctx.meta
 			if holdsem {

--- a/registry_test.go
+++ b/registry_test.go
@@ -62,7 +62,7 @@ func (t *testService) FooBar(foo string, bar int) (string, error) {
   return fmt.Sprintf("Hello World %v %v", foo, bar), nil
 }
 
-func (t *testService) Panic() (error) {
+func (t *testService) Panic(a string, b int) (error) {
   panic("Oh no!")
 }
 
@@ -267,7 +267,7 @@ func TestCallErrors(t *testing.T) {
 func TestPanic(t *testing.T) {
   registry := NewRegistry(16)
   registry.Register("test", &testService{})
-  _, err, _ := registry.Call(context.Background(), "test_panic", []json.RawMessage{}, nil, -1)
+  _, err, _ := registry.Call(context.Background(), "test_panic", []json.RawMessage{[]byte(`"foo"`), []byte("3")}, nil, -1)
   if err == nil { t.Errorf("Expected error, got none") }
   log.Info("The above stack trace is not indicative of a problem. We're testing that panics get handled properly, and part of that is logging the panic.")
 }

--- a/types.go
+++ b/types.go
@@ -145,16 +145,22 @@ func (lm *latestUnmarshaller) Resolve(await func(int64) bool, finalized, safe, l
 	lm.safeList = []*BlockNumber{}
 	lm.lock.Unlock()
 	if len(ll) > 0 && await(latest) {
-		for _, p := range ll {
-			*p = BlockNumber(latest)
+		for _, p := range ll {	
+			if p != nil {
+				*p = BlockNumber(latest)
+			}
 		}
 	}
 	// We don't need to await for safe or finalized, since those are older block numbers anyway.
 	for _, p := range fl {
-		*p = BlockNumber(finalized)
+		if p != nil {
+			*p = BlockNumber(finalized)
+		}
 	}
 	for _, p := range sl {
-		*p = BlockNumber(safe)
+		if p != nil {
+			*p = BlockNumber(safe)
+		}
 	}
 }
 


### PR DESCRIPTION
It turns out there's a bit of a race condition possible when the latest block number is not specified by the header. A call that doesn't specify the latest block number header will still have its BlockNumbers collected by lm, and those will get processed by the lock holder. This becomes a problem when time has passed and those arguments have zeroed out and the pointers become nil.

Rather than trying to totally protect against the race condition, which could have negative performance implications, we're just trying to protect against the nil pointer exception. This could result in some calls that don't specify the header having their values filled in by other processes that do, but I think the performance there is worth the risk of ambiguous behavior for someone who has just asked for the latest block, which is already somewhat ambiguous.